### PR TITLE
Downgrade Gradle

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,16 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
+    },
+    {
+      "matchManagers": [
+        "gradle-wrapper"
+      ],
+      "groupName": "Gradle Wrapper",
+      "automerge": false,
+      "labels": [
+        "requires-approval"
+      ]
     }
   ],
   "automerge": true,


### PR DESCRIPTION
- Downgrade Gradle from 8.10.1 to 8.9 due to known iOS build issues. No fix yet.
- Update Renovate rules to manually approve gradle updates