### PR TITLE
Renovate: lift manual approval for Gradle updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,16 +30,6 @@
         "com.google.devtools.ksp"
       ],
       "groupName": "kotlin"
-    },
-    {
-      "matchManagers": [
-        "gradle-wrapper"
-      ],
-      "groupName": "Gradle Wrapper",
-      "automerge": false,
-      "labels": [
-        "requires-approval"
-      ]
     }
   ],
   "automerge": true,


### PR DESCRIPTION
Gradle has now fixed the iOS build issues. It is good to allow Renovate to update it automatically again.